### PR TITLE
Hot fix lot 9 can't update family

### DIFF
--- a/src/actions.js
+++ b/src/actions.js
@@ -42,6 +42,7 @@ const FAMILY_HEAD_PROJECTION = (mm) => [
   "phone",
   "healthFacility" + mm.getProjection("location.HealthFacilityPicker.projection"),
   "incomeLevel{id, firstLanguage, secondLanguage}",
+  "fixIncome",
   "preferredPaymentMethod", 
   "bankCoordinates", 
   "coordinates",


### PR DESCRIPTION
Ajout fix-income dans la projection de had insuree pour que l'on puisse modifier la famille